### PR TITLE
Release v0.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@srwild/alpinejs-content-link",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@srwild/alpinejs-content-link",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "MIT",
       "devDependencies": {
         "@playwright/test": "^1.62.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@srwild/alpinejs-content-link",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Alpinejs directive to add interactive elements to content blocks.",
   "author": "S.R. Wild",
   "type": "module",


### PR DESCRIPTION
Prepare version `0.1.2` for release to npm.

## Changes

- Update the package version to `0.1.2`
- Update the package lockfile

## Validation

- [x] Automated tests pass
- [x] Package builds successfully
- [x] Package contents verified with `npm pack --dry-run`